### PR TITLE
async/await because callback trees are dumb

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ repo for an example of a repo that has been `git-schmeared`.
 
 ## TODO
 
+- ~~literally any testing~~
 - Variable intervals of schmear, as opposed to 1 day intervals.
 - Preserving `git` authorship, which is currently blown away.
 - Take start time as a CLI parameter and distribute commits from then until now.

--- a/README.md
+++ b/README.md
@@ -20,5 +20,7 @@ repo for an example of a repo that has been `git-schmeared`.
 
 ## TODO
 
+- Working on something other than `master`
+- preserving `git` authorship, which is currently blown away
 - evenly distributing commits over a given time frame.
 - take start as a CLI flag and evenly distribute commits from then till now

--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
 ##  `git-schmear`
 
-Spread the existing commits over a timeframe.
+Spread the existing commits over a timeframe. Use this to pretend like you've
+been working this whole time, rather than cramming in everything at the last
+minute.
 
 ## Running yourself
 
-```
+```sh
 cd /repo/you/want/to/spoof/
 cp /path/to/this/repo/forge.js .
 node forge.js
 ```
 
-If you want to spoof a fresh repo, try running `spoof.sh` to get yourself some
-freshly minted commits. You can see [this](https://github.com/SivanMehta/git-schmeared)
+If you want to spoof a fresh repo, copy over `spoof.sh` to get yourself some
+freshly minted commits. You can see [this](schmeared)
 repo for an example of a repo that has been `git-schmeared`.
-
-## Features
-
-- Preserves commit messages
 
 ## TODO
 
-- Working on something other than `master`
-- preserving `git` authorship, which is currently blown away
-- evenly distributing commits over a given time frame.
-- take start as a CLI flag and evenly distribute commits from then till now
+- Variable intervals of schmear, as opposed to 1 day intervals.
+- Preserving `git` authorship, which is currently blown away.
+- Take start time as a CLI parameter and distribute commits from then until now.
+
+[schmeared]: https://github.com/SivanMehta/git-schmeared

--- a/forge.js
+++ b/forge.js
@@ -1,4 +1,6 @@
-const { exec } = require('child_process');
+let { exec } = require('child_process');
+const { promisify } = require('util');
+const exec2 = promisify(exec);
 
 const ONE_DAY = 1000 * 60 * 60 * 24;
 const today = new Date();
@@ -8,18 +10,18 @@ class Runner {
     this.messageStack = [];
   }
 
-  start() {
-    exec('git log --oneline', (error, stdout, stderr) => {
-      const shas = stdout
-        .split('\n')
-        .map(line => line.replace(/commit /, ''))
-        .filter(line => line.length > 0);
+  async start() {
+    const { stdout } = await exec2('git log --oneline');
 
-      this.days = shas.length;
-      this.beginning = new Date(+today - ONE_DAY * this.days);
+    const shas = stdout
+      .split('\n')
+      .map(line => line.replace(/commit /, ''))
+      .filter(line => line.length > 0);
 
-      this.buildStack(shas.length);
-    });
+    this.days = shas.length;
+    this.beginning = new Date(+today - ONE_DAY * this.days);
+
+    this.buildStack(shas.length);    
   }
 
   /**

--- a/forge.js
+++ b/forge.js
@@ -36,7 +36,7 @@ class Runner {
     this.days = shas.length;
     this.beginning = new Date(+today - ONE_DAY * this.days);
 
-    this.buildStack(shas.length);
+    await this.buildStack(shas.length);
   }
 
   /**
@@ -70,7 +70,7 @@ class Runner {
       const commit = formCommit(message, day);
 
       await exec(commit);
-      await this.rebuildStack(idx);
+      await this.rebuildRepo(idx);
     } else {
       await exec('git reset --soft HEAD~');
       await exec('git stash');
@@ -86,7 +86,7 @@ class Runner {
    * @param  {Number} size - how many commits we have built so far
    * @async
    */
-  async rebuildStack(size) {
+  async rebuildRepo(size) {
     await exec('git stash pop');
 
     const day = this.formDay(size);
@@ -97,10 +97,12 @@ class Runner {
     const { stdout } = await exec('git stash list | wc -l');
     const completed = this.days - parseInt(stdout.match(/[0-9]+/)[0]);
     if(this.messageStack.length > 0) {
-      await this.rebuildStack(completed + 1);
+      await this.rebuildRepo(completed + 1);
     }
   }
 }
 
-const runner = new Runner();
-runner.start();
+(async function () {
+  const runner = new Runner();
+  await runner.start();
+})();

--- a/forge.js
+++ b/forge.js
@@ -94,9 +94,9 @@ class Runner {
     const commit = formCommit(message, day);
     await exec(commit);
 
-    const { stdout } = await exec('git stash list | wc -l');
-    const completed = this.days - parseInt(stdout.match(/[0-9]+/)[0]);
     if(this.messageStack.length > 0) {
+      const { stdout } = await exec('git stash list | wc -l');
+      const completed = this.days - parseInt(stdout.match(/[0-9]+/)[0]);
       await this.rebuildRepo(completed + 1);
     }
   }

--- a/forge.js
+++ b/forge.js
@@ -29,20 +29,19 @@ class Runner {
    * in git's stash stack
    * @param {Number} idx - which text file we're reverting
    */
-  buildStack(idx) {
-    exec('git log --oneline -1 --pretty=%B', (err, stdout) => {
-      const lines = stdout.split('\n');
-      const message = lines.slice(0, lines.length - 2).join('\n');
+  async buildStack(idx) {
+    const { stdout } = await exec2('git log --oneline -1 --pretty=%B');
+    const lines = stdout.split('\n');
+    const message = lines.slice(0, lines.length - 2).join('\n');
 
-      exec('git reset --soft HEAD~', () => {
-        exec('git stash', () => {
-          if(idx > 1) {
-            this.messageStack.push(message);
-            this.buildStack(idx - 1);
-          } else {
-            this.rebuildStack(idx);
-          }
-        });
+    exec('git reset --soft HEAD~', () => {
+      exec('git stash', () => {
+        if(idx > 1) {
+          this.messageStack.push(message);
+          this.buildStack(idx - 1);
+        } else {
+          this.rebuildStack(idx);
+        }
       });
     });
   }

--- a/spoof.sh
+++ b/spoof.sh
@@ -1,6 +1,6 @@
-for i in {1..100}
+for i in {1..10}
 do
-  echo "I am text file $i / 100" > data/$i.txt
+  echo "I am text file $i / 10" > data/$i.txt
   git add data/*.txt
   git commit -m "Added data/$i.txt
 this will form a full fleshed out commit message


### PR DESCRIPTION
In addition to `async/await` this PR does the following:

- Fixes bug where the Node.js call stack overflows if your commit history is too large.
- Adds documentation everywhere
- Clarifies what is this is even for.